### PR TITLE
switch to vim-go; jnwhiteh/vim-golang is no more

### DIFF
--- a/NeoBundle.vim
+++ b/NeoBundle.vim
@@ -79,10 +79,7 @@ NeoBundleLazy 'tpope/vim-fireplace', {'autoload': {'filetypes': ['clojure']}}
 " Scala
 NeoBundleLazy 'derekwyatt/vim-scala', {'autoload': {'filetypes': ['scala']}}
 " Go
-NeoBundleLazy 'jnwhiteh/vim-golang', {'autoload': {'filetypes': ['go']}}
-NeoBundleLazy 'dgryski/vim-godef', {'autoload': {'filetypes': ['go']}}
-NeoBundleLazy 'golang/lint', {'rtp': 'misc/vim', 'autoload': {'filetypes': ['go']}}
-NeoBundleLazy 'nsf/gocode', {'rtp': 'vim', 'autoload': {'filetypes': ['go']}}
+NeoBundleLazy 'fatih/vim-go', {'autoload': {'filetypes': ['go']}}
 
 "   JavaScript
 NeoBundleLazy 'pangloss/vim-javascript', {'autoload':{'filetypes':['javascript']}}

--- a/lib/auto_commands.vim
+++ b/lib/auto_commands.vim
@@ -49,7 +49,6 @@ if has("autocmd")
 
   augroup golang
     autocmd FileType go compiler go
-    autocmd FileType go autocmd BufWritePre <buffer> Fmt
     autocmd! BufEnter *.go call golang#buffcommands()
   augroup END
 


### PR DESCRIPTION
vim-go seems to be pretty nice. it's kind of a super-plugin and replaces a few things, not just syntax. the autofmt that it provides out of the box is also smarter about undo handling.

i'm not 100% sure if it's a drop-in replacement for the four plugins I removed (just that it mentions them in its readme), so you may want to smoke-test the keybindings/integration that you expect from them.

removed the auto fmt command which vim-go handles as well.
