### PR TITLE
Don't break Macvim default of Cmd-t for new tab.

### DIFF
--- a/gvimrc
+++ b/gvimrc
@@ -1,7 +1,5 @@
 " Unbind these keys for different bindings in vimrc
 if has('gui_macvim')
-  " D-t
-  macmenu &File.New\ Tab key=<nop>
   " D-p
   macmenu &File.Print key=<nop>
 


### PR DESCRIPTION
- Config doesn't otherwise use command-t key binding, so doesn't seem to be a reason to override it.
