### PR TITLE
Add support for running go lang tests with ginkgo

### DIFF
--- a/config/bindings.vim
+++ b/config/bindings.vim
@@ -128,3 +128,6 @@ map <leader>t :call RunTestFile()<cr>
 " Run only the example under the cursor
 map <leader>T :call RunNearestTest()<cr>
 " }}}
+
+map <leader><space> :Vipe <CR>
+map <leader>p :VipePop <CR>

--- a/lib/functions.vim
+++ b/lib/functions.vim
@@ -99,7 +99,7 @@ function! RunTestFile(...)
   endif
 
   " Run the tests for the previously-marked file.
-  let in_test_file = match(expand("%"), '\(.feature\|_spec.rb\)$') != -1
+  let in_test_file = match(expand("%"), '\(.feature\|_spec.rb\|_test.go\)$') != -1
   if in_test_file
     call RunTests(expand("%") . command_suffix)
   else
@@ -130,6 +130,12 @@ function! RunTests(filename)
       let command = "bundle exec cucumber " . a:filename
     else
       let command = "cucumber " . a:filename
+    end
+  elseif match(a:filename, '_test\.go') != -1
+    if filereadable("script/test")
+      let command = "script/test " . fnamemodify(a:filename, ':h')
+    else
+      let command = "ginkgo " . fnamemodify(a:filename, ':h')
     end
   else
     if filereadable("script/test")


### PR DESCRIPTION
Example:

Say a file `some/package/with_a_test.go` is being edited. When
`RunTests(some/package/with_a_test.go)` is called it will pass the
package of the currently edited test file, i.e. `some/package`, to either
`script/test` or `ginkgo` by default.

I have found this useful while deveoping in go so though I would
contribute.

Sorry there are no tests for this, was not sure how to test this as
there are no exsisting tests (that I could see).