### PR TITLE
Removes NERDTree key binding that overrides column jumping.

### DIFF
--- a/Plug.vim
+++ b/Plug.vim
@@ -99,7 +99,6 @@ call plug#begin('~/.vim/plugged')
   Plug 'tpope/vim-repeat'
   Plug 'tpope/vim-sleuth'
   Plug 'tpope/vim-unimpaired'
-  Plug 'Townk/vim-autoclose', { 'on': 'AutoCloseOn' }
 
   if has('nvim')
     Plug 'Shougo/deoplete.nvim'

--- a/Plug.vim
+++ b/Plug.vim
@@ -77,6 +77,7 @@ call plug#begin('~/.vim/plugged')
 
   " Go {{{
     Plug 'fatih/vim-go'
+    Plug 'nsf/gocode', { 'rtp': 'vim', 'do': '~/.vim/plugged/gocode/vim/symlink.sh' }
   " }}}
 
   " Docker {{{

--- a/Plug.vim
+++ b/Plug.vim
@@ -1,15 +1,10 @@
 call plug#begin('~/.vim/plugged')
 
 " Defaults {{{
-  Plug 'tpope/vim-sensible'
 " }}}
 
 " Navigation {{{
-  Plug 'majutsushi/tagbar'
-  Plug 'scrooloose/nerdtree'
-  Plug 'tpope/vim-projectionist'
   Plug 'bogado/file-line'
-
   Plug 'junegunn/fzf', { 'do': 'yes \| ./install'  }
   if !has('nvim')
     Plug 'ctrlpvim/ctrlp.vim'
@@ -18,77 +13,17 @@ call plug#begin('~/.vim/plugged')
 " }}}
 
 " UI Additions {{{
-  " Colors {{{
-    Plug 'dolio/vim-hybrid'
-    Plug 'chriskempson/base16-vim'
-    Plug 'flazz/vim-colorschemes'
-  " }}}
-
-  Plug 'luochen1990/rainbow'
-  Plug 'bling/vim-airline'
-  Plug 'kshenoy/vim-signature'
-  Plug 'mhinz/vim-signify'
-  Plug 'jszakmeister/vim-togglecursor'
-  Plug 'christoomey/vim-tmux-navigator'
 " }}}
 
 " Commands {{{
-  function! InstallVipe(info)
-    if a:info.status == 'installed' || a:info.force
-      if has("unix")
-        let s:uname = system("uname -s")
-        if s:uname =~ "Darwin"
-          silent !rm -f /usr/local/bin/vipe
-          silent !ln -s `pwd`/vipe /usr/local/bin || true
-        else
-          silent !ln -s `pwd`/vipe ~/bin || true
-        endif
-      endif
-    endif
-  endfunction
-
-  function! InstallVimProc(info)
-    if a:info.status == 'installed' || a:info.force
-      if has("unix")
-        let s:uname = system("uname -s")
-        if s:uname =~ "Darwin"
-          silent !make -f make_mac.mak
-        elseif s:uname =~ "Linux"
-          silent !make
-        else
-          silent !gmake
-        endif
-      elseif has("win32unix")
-        silent !make -f make_cygwin.mak
-      elseif has('win32')
-        silent !tools\update-dll-mingw
-      endif
-    endif
-  endfunction
-
-  Plug 'Shougo/vimproc.vim',             { 'do': function('InstallVimProc') }
-  Plug 'tpope/vim-commentary'
   Plug 'tpope/vim-surround'
   Plug 'tpope/vim-fugitive'
-  Plug 'gregsexton/gitv',                { 'on': 'Gitv'                  }
-  Plug 'tpope/vim-abolish'
-  Plug 'tpope/vim-eunuch'
-  Plug 'Peeja/vim-cdo'
-  Plug 'godlygeek/tabular'
-  Plug 'mileszs/ack.vim',                { 'on': 'Ack'                   }
-  Plug 'rking/ag.vim',                   { 'on': 'Ag'                    }
-  Plug 'luan/vipe',                      { 'do': function('InstallVipe') }
-  Plug 'tpope/vim-dispatch'
   if has('nvim')
     Plug 'benekastah/neomake'
   else
     Plug 'scrooloose/syntastic'
   endif
-  Plug 'milkypostman/vim-togglelist'
-  Plug 'terryma/vim-multiple-cursors'
-  Plug 'maxbrunsfeld/vim-emacs-bindings'
   Plug 'mbbill/undotree'
-
   Plug 'google/vim-maktaba'
   Plug 'google/vim-codefmt'
   Plug 'google/vim-glaive'
@@ -115,11 +50,6 @@ call plug#begin('~/.vim/plugged')
   Plug 'kana/vim-textobj-user'
   Plug 'lucapette/vim-textobj-underscore'
   Plug 'nelstrom/vim-textobj-rubyblock'
-" }}}
-
-" Snippets {{{
-  Plug 'Shougo/neosnippet.vim'
-  Plug 'Shougo/neosnippet-snippets'
 " }}}
 
 " Language specific {{{

--- a/config/basic.vim
+++ b/config/basic.vim
@@ -28,6 +28,7 @@ if !has('nvim')
   set ttyfast
 endi
 set lazyredraw
+set splitright
 if exists('+colorcolumn')
   set colorcolumn=80 " Color the 80th column differently
 endif

--- a/config/plugin/NERDTree.vim
+++ b/config/plugin/NERDTree.vim
@@ -4,7 +4,6 @@
 nnoremap <leader>nn :NERDTreeToggle<CR>
 nnoremap \ :NERDTreeToggle<CR>
 nnoremap <leader>nf :NERDTreeFind<CR>
-nnoremap \| :NERDTreeFind<CR>
 let g:NERDTreeShowBookmarks=1
 let g:NERDTreeChDirMode=2 " Change the NERDTree directory to the root node
 autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTreeType") && b:NERDTreeType == "primary") | q | endif

--- a/config/plugin/autoclose.vim
+++ b/config/plugin/autoclose.vim
@@ -1,8 +1,0 @@
-" vim mode-switch lag fix
-if ! has("gui_running")
-  set ttimeoutlen=10
-  augroup FastEscape autocmd!
-    au InsertEnter * set timeoutlen=50
-    au InsertLeave * set timeoutlen=1000
-  augroup END
-endif

--- a/vimrc
+++ b/vimrc
@@ -59,4 +59,4 @@ silent! source ~/.vimrc.local
 
 color desert
 inoremap jk <esc>
-
+set backspace=indent,eol,start

--- a/vimrc
+++ b/vimrc
@@ -26,8 +26,6 @@ runtime! config/platform.vim
 
 runtime! config/plugin/NERDTree.vim
 runtime! config/plugin/ack.vim
-runtime! config/plugin/airline.vim
-runtime! config/plugin/autoclose.vim
 runtime! config/plugin/commentary.vim
 runtime! config/plugin/echodoc.vim
 runtime! config/plugin/fugitive.vim

--- a/vimrc
+++ b/vimrc
@@ -57,3 +57,6 @@ runtime! lib/auto_commands.vim
 
 silent! source ~/.vimrc.local
 
+color desert
+inoremap jk <esc>
+


### PR DESCRIPTION
Removes NERDTree key binding that overrides column jumping. See:
http://stackoverflow.com/questions/9953082/how-to-jump-directly-to-a-column-number-in-vim