### PR TITLE
Configure syntastic to use flake8 for python files

### DIFF
--- a/config/plugin/syntastic.vim
+++ b/config/plugin/syntastic.vim
@@ -1,0 +1,1 @@
+let g:syntastic_python_checkers = ['flake8']

--- a/vimrc
+++ b/vimrc
@@ -38,6 +38,7 @@ runtime! config/plugin/neosnippet.vim
 runtime! config/plugin/omnicompletion.vim
 runtime! config/plugin/rainbow.vim
 runtime! config/plugin/signify.vim
+runtime! config/plugin/syntastic.vim
 runtime! config/plugin/tagbar.vim
 runtime! config/plugin/undotree.vim
 runtime! config/plugin/yaml.vim


### PR DESCRIPTION
- Pylint is too strict. It raises warning for things like missing
  docstrings, which distract from actual issues.
- Flake8 is a decent replacement that combines PyFlakes, PEP8, and a
  complexity checker.