### PR TITLE
Squash annoying error when running in fish shell

### DIFF
--- a/config/colors.vim
+++ b/config/colors.vim
@@ -52,7 +52,8 @@ function! colors#_change(index)
   endif
 
   let l:name = s:colors[idx]
-  if !has('gui_running') && name == 'hybrid'
+  let currentshell = $SHELL
+  if !has('gui_running') && name == 'hybrid' && currentshell != '/usr/bin/fish'
     silent !source $HOME/.vim/scripts/shell-colors-vim-hybrid/shell-colors-vim-hybrid.sh
   endif
   if !has('gui_running') && name == 'gruvbox'


### PR DESCRIPTION
Fish is incompatible with sh, so it's a bad idea to source regular shell
scripts when you're running it. See
http://fishshell.com/docs/current/tutorial.html for some details.