### PR TITLE
Skip backups for crontab

### DIFF
--- a/config/crontab.vim
+++ b/config/crontab.vim
@@ -1,0 +1,1 @@
+autocmd FileType crontab setlocal nobackup nowritebackup

--- a/vimrc
+++ b/vimrc
@@ -15,6 +15,7 @@ runtime! Plug.vim
 runtime! config/basic.vim
 runtime! config/bindings.vim
 runtime! config/colors.vim
+runtime! config/crontab.vim
 runtime! config/paste.vim
 
 " Platform Specific


### PR DESCRIPTION
If crontabs are not edited in place, the edit fails with:

crontab: temp file must be edited in place