### PR TITLE
Remove guioptions 'a' mode

### DIFF
--- a/config/basic.vim
+++ b/config/basic.vim
@@ -25,7 +25,7 @@ set cmdheight=1    " Make the command area two lines high
 set noshowmode     " don't need to show mode since we have airline
 set numberwidth=4
 set encoding=utf-8
-set guioptions=acg
+set guioptions=cg
 set guicursor=n-v-c:block-Cursor-blinkon0,ve:ver35-Cursor,o:hor50-Cursor,i-ci:ver25-Cursor,r-cr:hor20-Cursor,sm:block-Cursor-blinkwait175-blinkoff150-blinkon175
 set cursorline
 if !has('nvim')


### PR DESCRIPTION
This mode makes it so that visual selections will automatically be copied into the system clipboard

http://superuser.com/questions/348207/prevent-macvim-copying-every-visual-selection-to-clipboard
