### PR TITLE
Check if .git is an existing file or directory

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -69,7 +69,7 @@ from_repo() {
 
   (
   [[ -d "${dir}" ]] && cd "${dir}" || return 1
-  [[ -d "${dir}/.git" && "$(git remote -v)" == *"${VIMFILES_REPO_NAME}"* ]]
+  [[ -e "${dir}/.git" && "$(git remote -v)" == *"${VIMFILES_REPO_NAME}"* ]]
   )
 }
 


### PR DESCRIPTION
When this repo is a submodule, `.git` will be a file instead of a directory.