### PR TITLE
Always show quickfix in full-width bottom split

### DIFF
--- a/lib/autocommands.vim
+++ b/lib/autocommands.vim
@@ -29,5 +29,7 @@ if has("autocmd")
 
   au FileType qf nnoremap <buffer> <Enter> <Enter>
 
+  " quickfix list takes full width & wraps lines
   autocmd FileType qf wincmd J
+  autocmd FileType qf setlocal wrap
 endif

--- a/lib/autocommands.vim
+++ b/lib/autocommands.vim
@@ -28,4 +28,6 @@ if has("autocmd")
   augroup END
 
   au FileType qf nnoremap <buffer> <Enter> <Enter>
+
+  autocmd FileType qf wincmd J
 endif


### PR DESCRIPTION
By default it displays on the bottom-right if there is a vertical split, which makes long go errors not visible

Signed-off-by: Ben Moss <bmoss@pivotal.io>