### PR TITLE
Fix implicit `vim-scripts' expansion is deprecated error

### DIFF
--- a/Plug.vim
+++ b/Plug.vim
@@ -197,7 +197,7 @@ call plug#begin('~/.vim/plugged')
 
 " Text objects {{{
   " allows you to configure % to match more than just single characters
-  Plug 'matchit.zip'
+  Plug 'vim-scripts/matchit.zip'
 
   " Create your own text objects
   Plug 'kana/vim-textobj-user'


### PR DESCRIPTION
when I run `vim-update`, I get the following error.
```
[vim-plug] Invalid argument: matchit.zip (implicit `vim-scripts' expansion is deprecated)
```
Please see https://github.com/junegunn/vim-plug/commit/f7e6a86807a1f0be7257620a8c425e1a32f877bb