### PR TITLE
Re-add christoomey/vim-tmux-navigator plugin

### DIFF
--- a/Plug.vim
+++ b/Plug.vim
@@ -37,6 +37,9 @@ call plug#begin('~/.vim/plugged')
   " Show a diff via Vim sign column.
   Plug 'mhinz/vim-signify'
 
+  " Seamless navigation between tmux panes and vim splits
+  Plug 'christoomey/vim-tmux-navigator'
+
   " Better whitespace highlighting for Vim
   Plug 'ntpeters/vim-better-whitespace'
 


### PR DESCRIPTION
Hi Luan,

This plugin was removed in https://github.com/luan/vimfiles/commit/ddcb1480321c26ba28dab85106b03aa9544e805b#diff-217e7c20c644e9b3036ab8324350e64e, and it looks like it might have been an accident? Sorry if there's a reason I didn't see.