### PR TITLE
Actually run GoInstallBinaries during install

### DIFF
--- a/Plug.vim
+++ b/Plug.vim
@@ -194,7 +194,8 @@ call plug#begin('~/.vim/plugged')
   " }}}
 
   " Go {{{
-    Plug 'fatih/vim-go', { 'for': 'go', 'do': ':GoInstallBinaries' }
+    Plug 'fatih/vim-go', { 'for': 'go' }
+    Plug 'fatih/vim-go', { 'do': ':GoInstallBinaries' }
   " }}}
 
   " Markdown {{{


### PR DESCRIPTION
The `for: go` clause when trying to `do: GoInstallBinaries` in Plug.vim
was causing it not to run during installation.