### PR TITLE
Install neovim python plugins in home dir

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -252,11 +252,11 @@ setup_neovim_python3() {
     $PIP3 uninstall -y greenlet || true
     sudo pacman -S --noconfirm python-greenlet
   fi
-  $PIP3 install --upgrade neovim
+  $PIP3 install --user --upgrade neovim
 }
 
 setup_neovim_python2() {
-  $PIP2 install --upgrade neovim
+  $PIP2 install --user --upgrade neovim
 }
 
 setup_vim_calls() {


### PR DESCRIPTION
This is recommended by these docs: https://github.com/zchee/deoplete-jedi/wiki/Setting-up-Python-for-Neovim

Trying to install without this flag was giving me a permission failure
over
`/usr/local/lib/python2.7/site-packages/six-1.10.0.dist-info/DESCRIPTION.rst`