### PR TITLE
Remove the `--with-lua` instructions for brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ guide](https://github.com/neovim/neovim/wiki/Installing-Neovim) in order to get
 it properly setup. The autocompletion plugin we use needs [python3
 support](https://github.com/zchee/deoplete-jedi/wiki/Setting-up-Python-for-Neovim) too.
 
-If you're using regular vim make sure to install it with lua support, on ubuntu
-that's provided with the `vim-nox` package and on OSX it can be installed with
-Homebrew by doing `brew install vim --with-lua`.
+If you choose regular vim you can install it on ubuntu via the `vim-nox` package, or
+on macOS with Homebrew via `brew install vim`. Note if you are using macOS High Sierra
+the pre-installed vim is v`8.0` which should work.
 
 ### Table of Contents
 


### PR DESCRIPTION
- `lua` is no longer required so this doesn't make sense any more.
- add note about macOS High Sierra pre-installed VIM

Note: the ubuntu package `vim-nox` may no longer be correct/required given that `lua` is no longer needed.