### PR TITLE
Remove unused g:signify_sign_overwrite global

### DIFF
--- a/config/plugin/signify.vim
+++ b/config/plugin/signify.vim
@@ -1,4 +1,3 @@
 let g:signify_update_on_bufenter = 1
-let g:signify_sign_overwrite = 1
 let g:signify_disable_by_default = 0
 


### PR DESCRIPTION
Looks like this was removed from vim-signify a while ago: https://github.com/mhinz/vim-signify/commit/fe3bafce1180881f5d2a4ffa9b7e9c0d5c853fc4.

I also considered removing `g:signify_disable_by_default`, since the default is already `0`, but figured it's not bad to set it explicitly. Curious if you have a specific reason for setting it explicitly though?