### PR TITLE
Improve color rendering for 'tmux*' terminals

### DIFF
--- a/config/colors.vim
+++ b/config/colors.vim
@@ -92,7 +92,7 @@ set background=dark
 
 if has('termguicolors')
   set termguicolors
-  if &term =~# '^screen'
+  if &term =~# '^screen' || &term =~# '^tmux'
     let &t_8f = "\<Esc>[38;2;%lu;%lu;%lum"
     let &t_8b = "\<Esc>[48;2;%lu;%lu;%lum"
   endif


### PR DESCRIPTION
Not just 'screen*'.

I use `set -g default-terminal "tmux-256color"` in order to enable support for
italics inside tmux. This patch sets t_8f and t_8b in configurations like mine.