### PR TITLE
Fix installation on Arch Linux

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -228,14 +228,13 @@ setup_livedown() {
 
 setup_neovim_python3() {
   if which pacman > /dev/null ; then
-    sudo $PIP uninstall -y greenlet 2>/dev/null >/dev/null|| true
-    sudo pacman -S --noconfirm python-greenlet
+    sudo $PIP uninstall -y greenlet 2>/dev/null >/dev/null || true
+    sudo pacman -S --needed --noconfirm python-greenlet
+    sudo $PIP install --upgrade neovim
+    return 0
   fi
-  if which virtualenv; then
-    $PIP install --upgrade neovim
-  else
-    $PIP install --user --upgrade neovim
-  fi
+
+  $PIP install --upgrade neovim
 }
 
 setup_vim_calls() {


### PR DESCRIPTION
Globally install neovim pip package. I think this makes sense given that the
python-greenlet package is removed as root.

I'm not sure what to do in the non-Arch cases. For Homebrew users on macOS, pip
can be run as non-root and without `--user` due to the writeability of
/usr/local. On most Linux systems, pip without `--user` will not run as
non-root. Some users will want to install the neovim package as root, some will
want to use `--user`. Perhaps a flag? What do you think?

I'm not sure testing for the presence of virtualenv to decide this makes sense,
as users often won't have a virtualenv loaded, causing the non-`--user` case to
fail. I might be massively wrong about that, I don't use Python much at all.

Additionally, use `--needed` with `pacman -S` to avoid reinstallation.