### PR TITLE
Introduce the `iferr` golang snippet

### DIFF
--- a/UltiSnips/go.snippets
+++ b/UltiSnips/go.snippets
@@ -8,6 +8,12 @@ snippet printf "fmt.Printf(format, ...)"
 fmt.Printf("${1:%s}", ${0:${VISUAL}})
 endsnippet
 
+snippet iferr "if err != nil {...}"
+if err != nil {
+	${0}
+}
+endsnippet
+
 snippet desc "Ginkgo Describe" b
 Describe("${1:something}", func() {
 	${0:${VISUAL}}


### PR DESCRIPTION
Golang developers often have to check for errors and handle them
appropriately. Writing code similar to

```golang
if err != nil {
// do something fancy here
}
```
is very common and therefore it would be great to have a shortcut for
that.

There are some error handling snippets existing [here](https://github.com/fatih/vim-go/blob/0b7e453774aec11e9d07b6d9126e3d583c6ac2ce/gosnippets/snippets/go.snip#L129-L173) but I don't really feel them to be "general purpose" as they are doing something concrete to handle the error (e.g. panic, log, fail a test)