### PR TITLE
Put markdown and nerdtree autocmds in groups

### DIFF
--- a/config/lang/markdown.vim
+++ b/config/lang/markdown.vim
@@ -1,2 +1,5 @@
-autocmd BufNewFile,BufRead *.md setlocal spell | setlocal lbr | setlocal nonu
+augroup luan_markdown
+  autocmd!
+  autocmd BufNewFile,BufRead *.md setlocal spell | setlocal lbr | setlocal nonu
+augroup END
 let g:markdown_fenced_languages = ['html', 'json', 'css', 'javascript', 'vim', 'go', 'ruby', 'python', 'bash=sh']

--- a/config/plugin/nerdtree.vim
+++ b/config/plugin/nerdtree.vim
@@ -8,5 +8,8 @@ nnoremap \| :NERDTreeFind<CR>
 let g:NERDTreeShowBookmarks=1
 let g:NERDTreeChDirMode=2 " Change the NERDTree directory to the root node
 let g:NERDTreeHijackNetrw=0
-autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTreeType") && b:NERDTreeType == "primary") | q | endif
+augroup luan_nerdtree
+  autocmd!
+  autocmd bufenter * if (winnr("$") == 1 && exists("b:NERDTreeType") && b:NERDTreeType == "primary") | q | endif
+augroup END
 


### PR DESCRIPTION
Recent travis builds fail with 
```
config/lang/markdown.vim:1:1: autocmd should execute in an augroup or execute with a group (see :help :autocmd)
config/plugin/nerdtree.vim:11:1: autocmd should execute in an augroup or execute with a group (see :help :autocmd)
```

This commit fixes the error above via putting `autocmd`s into `autogroup`s in the aforementioned files