### PR TITLE
Don't run missing gocode "drop-cache" command

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -263,7 +263,6 @@ setup_go_dependencies() {
   echo -e "${GREEN}DONE${END_COLOR} ${BOLD}go binaries${NORMAL}" >&4
   set +e
   GOPATH="${PWD}/gopath" GOBIN="${PWD}/gobin" "${PWD}/gobin/gocode" close 2>/dev/null
-  GOPATH="${PWD}/gopath" GOBIN="${PWD}/gobin" "${PWD}/gobin/gocode" drop-cache
   set -e
   )
 }


### PR DESCRIPTION
The github.com/mdempsky/gocode fork of github.com/nsf/gocode is
installed, which dropped support for drop-cache in
https://github.com/mdempsky/gocode/commit/e117c263fb7092eedd7cab24f41d90a9d76bd23a

With this use of drop-cache present, an install of vimfiles errors
after installing go binaries with:

```
gocode: unknown subcommand: "drop-cache"
Run 'gocode -help' for usage.
```