### PR TITLE
ensure install returns success when go not installed

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -300,6 +300,7 @@ main() {
   install_plugins
 
   has_go && setup_go_dependencies
+  return 0
 }
 
 main "$@"


### PR DESCRIPTION
Any bash function will implicitly return the value of the last evaluated expression.

From the [bash documentation](https://www.gnu.org/software/bash/manual/html_node/Shell-Functions.html#Shell-Functions)

> When executed, the exit status of a function is the exit status of the last command executed in the body.

When go is not installed the expression `has_go && setup_go_dependencies` will return non zero, as it is the last expression of `main` it also returns non zero. This in turn causes the script to return non zero. This gives the appearance the script has failed even though it succeeded.

The simple solution is to call `return 0` at the bottom of the main function.