### PR TITLE
Add warning about the pynvim package name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ If that doesn't work you can always run the script directly:
 ~/.vim/update
 ```
 
+On 11/18/2018 the Python package `neovim` was renamed to `pynvim`
+Due to issues with pip the `neovim` pip package cannot be upgraded and will break neovim's python bindings.
+
+To resolve this you can run
+```bash
+pip uninstall noevim pynvim
+pip install pynvim
+```
+
+See https://github.com/neovim/neovim/wiki/Following-HEAD#20181118 for more details
+
 ---
 
 ## Customizing


### PR DESCRIPTION
A couple months ago the neovim python package was renamed and `broke pip install --upgrade neovim`

This PR adds a warning to the README of this repo but doesn't resolve the underlying issue (that `install` will break a Vimfiles setup that previously had `neovim` installed when it [runs `sudo $PIP install --upgrade neovim`](https://github.com/luan/vimfiles/blob/de7e15c9560a3653cdfeb12a4f9e082e18a945a1/bin/install#L229-L238).

I propose an additional change (not included in this PR pending discussion) to `install` that would detect a previously installed `neovim` package, uninstall it (and potentially any `pynvim` that is present), and directly install `pynvim`. This could potentially be achieved with `$PIP show neovim`.
