### PR TITLE
Disable modeline

### DIFF
--- a/config/basic.vim
+++ b/config/basic.vim
@@ -61,6 +61,10 @@ set viewoptions=cursor,folds,slash,unix
 set scrolloff=5
 " }}}
 
+" Security {{{
+set nomodeline
+" }}}
+
 " Text Format {{{
 set tabstop=2
 set shiftwidth=2 " Tabs under smart indent


### PR DESCRIPTION
Due to the following security issue with modeline (patched in latest versions of Vim and Nvim) it is recommended to disable modeline and use the secure modeline plugin or other configuration tools instead.

see https://github.com/numirias/security/blob/master/doc/2019-06-04_ace-vim-neovim.md