### PR TITLE
Change linter to golangci-lint

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -259,7 +259,6 @@ setup_go_dependencies() {
   echo -e "${YELLOW}INSTALL${END_COLOR} ${BOLD}go binaries${NORMAL} (may take a while)..." >&4
   GOPATH="${PWD}/gopath" ${VIMCMD} +'GoUpdateBinaries' +'qall!'
   echo
-  GOPATH="${PWD}/gopath" GOBIN="${PWD}/gobin" "${PWD}/gobin/gometalinter" --install --update
   echo -e "${GREEN}DONE${END_COLOR} ${BOLD}go binaries${NORMAL}" >&4
   set +e
   GOPATH="${PWD}/gopath" GOBIN="${PWD}/gobin" "${PWD}/gobin/gocode" close 2>/dev/null

--- a/config/lang/golang.vim
+++ b/config/lang/golang.vim
@@ -29,14 +29,12 @@ let s:go_tags_script_path = resolve(expand('<sfile>:h') . '/../../scripts/gotags
 let s:go_tags_lock_path = resolve(expand('<sfile>:h') . '/../../tmp/gotagslock')
 
 let g:go_auto_type_info = 0
-
-let g:ale_go_gometalinter_options =
-      \ '--tests ' .
-      \ '--fast ' .
-      \ '--disable=gotype ' .
-      \ '--disable=gotypex ' .
-      \ '--exclude="should have comment" ' .
-      \ '--exclude="error return value not checked \(defer"'
+let g:ale_go_golangci_lint_package = 1
+let g:ale_go_golangci_lint_options = '--enable-all
+\ --tests
+\ --fast
+\ --disable gochecknoglobals
+\ --disable gochecknoinits'
 
 function! golang#project_tags_path()
   return s:go_tags_path . '/' . substitute(expand('%:p'), '/', '--', 'g') . '--tags'

--- a/config/plugin/ale.vim
+++ b/config/plugin/ale.vim
@@ -9,7 +9,7 @@ let g:ale_sign_info = '➟'
 let g:ale_sign_column_always = 1
 
 let g:ale_linters = {
-\   'go': ['go build', 'gofmt', 'gometalinter'],
+\   'go': ['go build', 'gofmt', 'golangci-lint'],
 \   'typescript': ['tsserver', 'typecheck'],
 \   'javascript': ['eslint'],
 \}


### PR DESCRIPTION
Gometalinter has been deprecated in favour of `golangci-lint`. `vim-go` has even drop support for it: https://github.com/fatih/vim-go/pull/2494