### PR TITLE
Add vim-orgmode for editing org files

### DIFF
--- a/Plug.vim
+++ b/Plug.vim
@@ -137,6 +137,9 @@ Plug 'junegunn/goyo.vim'
 
 " All the world's indeed a stage and we are merely players
 Plug 'junegunn/limelight.vim'
+
+" Make ^a and ^x work properly with dates
+Plug 'tpope/vim-speeddating'
 " }}}
 
 " Automatic Helpers {{{
@@ -313,6 +316,7 @@ Plug 'keith/rspec.vim'
 Plug 'hashivim/vim-terraform'
 Plug 'PProvost/vim-ps1'
 Plug 'ciaranm/securemodelines' " Secure modeline https://github.com/numirias/security/blob/master/doc/2019-06-04_ace-vim-neovim.md
+Plug 'jceb/vim-orgmode'
 " }}}
 " }}}
 


### PR DESCRIPTION
This PR pulls in [vim-orgmode](https://github.com/jceb/vim-orgmode) for editing [org mode](https://orgmode.org/) files in vim.

That plugin depends on [speeddating](https://github.com/tpope/vim-speeddating), which makes control-a and control-x arithmetic work properly with things formatted like dates.